### PR TITLE
Implement Application Settings and Preferences Dialog

### DIFF
--- a/data/io.github.tobagin.KeySmith.gschema.xml
+++ b/data/io.github.tobagin.KeySmith.gschema.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="keysmith">
+  <schema id="io.github.tobagin.KeySmith" path="/io/github/tobagin/KeySmith/">
+    <key name="default-key-type" type="s">
+      <default>'Ed25519'</default>
+      <summary>Default SSH key type</summary>
+      <description>The default algorithm to select when generating new SSH keys (e.g., Ed25519, RSA).</description>
+    </key>
+    <key name="default-rsa-bits" type="i">
+      <default>4096</default>
+      <summary>Default bit length for RSA keys</summary>
+      <description>The default bit length to use when generating new RSA keys.</description>
+      <range min="2048" max="16384"/>
+    </key>
+    <!-- Add other preferences here in the future -->
+  </schema>
+</schemalist>

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,12 @@ install_data(
   install_dir: get_option('datadir') / 'icons' / 'hicolor' / 'scalable' / 'apps'
 )
 
+# GSettings schema
+install_data(
+  'data/' + keysmith_name + '.gschema.xml',
+  install_dir: get_option('datadir') / 'glib-2.0' / 'schemas'
+)
+
 # Translations
 po_dir = join_paths(meson.source_root(), 'po')
 gnome.post_install_update_icon_cache(true)

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -2,12 +2,43 @@
 
 import os
 import subprocess
+import sys # Add sys import
 
 def main():
-    # Placeholder for any post-install actions
-    # For example, compiling GSettings schemas if they were used.
-    # For now, it does nothing.
     print("Meson post-install script executed.")
+
+    # Compile GSettings schemas
+    # Determine the schemas directory based on environment variables Meson sets
+    # or common system paths. Meson's install prefix is key.
+    datadir = os.environ.get('MESON_INSTALL_DESTDIR_PREFIX')
+    if not datadir:
+        # If MESON_INSTALL_DESTDIR_PREFIX is not set (e.g. not in a DESTDIR install)
+        # then datadir is just the prefix itself.
+        datadir = os.environ.get('MESON_INSTALL_PREFIX', '/usr/local') # Default if not found
+
+    schemas_dir = os.path.join(datadir, 'share', 'glib-2.0', 'schemas')
+
+    print(f"Checking for GSettings schemas in: {schemas_dir}")
+    if os.path.isdir(schemas_dir):
+        print(f"Compiling GSettings schemas in {schemas_dir}...")
+        try:
+            subprocess.run(["glib-compile-schemas", schemas_dir], check=True)
+            print("GSettings schemas compiled successfully.")
+        except FileNotFoundError:
+            print("Error: glib-compile-schemas command not found. Please ensure it is installed.", file=sys.stderr)
+            # sys.exit(1) # Optionally exit with error
+        except subprocess.CalledProcessError as e:
+            print(f"Error: Failed to compile GSettings schemas: {e}", file=sys.stderr)
+            # sys.exit(1) # Optionally exit with error
+        except Exception as e:
+            print(f"An unexpected error occurred during schema compilation: {e}", file=sys.stderr)
+            # sys.exit(1)
+    else:
+        print(f"GSettings schemas directory not found: {schemas_dir}. Skipping compilation.", file=sys.stderr)
+
+    # Placeholder for other post-install actions (e.g., updating icon cache, already there)
+    # For example, compiling GSettings schemas if they were used.
+    # For now, it does nothing more.
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This commit introduces an application preferences system using GSettings, allowing you to configure default key generation parameters.

Key changes include:

- GSettings Integration:
  - Added `io.github.tobagin.KeySmith.gschema.xml` defining keys for `default-key-type` (String, default: "Ed25519") and `default-rsa-bits` (Integer, default: 4096).
  - Updated `meson.build` to install the schema.
  - Updated `meson_post_install.py` to compile the schema.

- PreferencesDialog (`Adw.PreferencesWindow`):
  - Created a new dialog accessible from the main menu.
  - Allows you to set the "Default Key Type" (Ed25519, RSA) via an `Adw.ComboRow`.
  - Allows you to set the "Default RSA Bit Size" (2048, 3072, 4096, 8192) via an `Adw.ComboRow`. This row is only sensitive if "RSA" is the selected default key type.
  - Settings are stored and retrieved using GSettings, with two-way manual synchronization between UI widgets and GSettings keys.

- Main Window and Application Menu:
  - Added standard "preferences", "about", and "quit" actions to `KeySmithApplication`.
  - Implemented an `Adw.AboutWindow`.
  - A `Gtk.MenuButton` in the `KeySmithWindow` HeaderBar now provides access to these actions.

- GenerateKeyDialog Enhancements:
  - The "Generate New Key" dialog now initializes its key type selection from the `default-key-type` GSetting.
  - A new `Adw.ComboRow` for "RSA Bit Size" is added to this dialog, visible and active only when "RSA" is the selected key type. Its initial value is populated from the `default-rsa-bits` GSetting.
  - The `ssh-keygen` command for RSA keys now includes the `-b <bits>` argument based on the selection in this dialog.

This feature provides you with customization options for default key generation and integrates standard application menu functionalities.